### PR TITLE
Fix Axios headers problems

### DIFF
--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -16,13 +16,19 @@ import {
   FormHelp,
 } from './Form'
 
+import jwt from '../utils/jwt'
+
 const LoginForm = (props) => {
   const { register, handleSubmit, errors } = useForm()
   const [message, setMessage] = useState('')
 
   const onSubmit = async (userData) => {
     try {
-      const response = await fetch.post('/users/login', userData)
+      const response = await fetch.post('/users/login', userData, {
+        headers: {
+          Authorization: `Bearer ${jwt.getToken()}`,
+        },
+      })
       if (response) {
         storage.setKey('token', response.data.token)
         props.setIsLoggedIn(true)

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -14,14 +14,22 @@ import {
   FormHelp,
 } from './Form'
 
+import jwt from '../utils/jwt'
+
 const RegisterForm = (props) => {
   const { register, handleSubmit, errors } = useForm()
   const [message, setMessage] = useState('')
 
   const onSubmit = async (userData) => {
     try {
-      await fetch.post('/users/register', userData)
-      props.history.push('/register/success')
+      await fetch.post('/users/register', userData, {
+        headers: {
+          Authorization: `Bearer ${jwt.getToken()}`,
+        },
+      })
+      props.setIsRegistered(true)
+      // Don't use props.history.push() as
+      // it causes race condition problem with the token retrieval
     } catch (error) {
       setMessage(error.response.data.message)
     }

--- a/src/components/UsersList.js
+++ b/src/components/UsersList.js
@@ -4,6 +4,7 @@ import axios from 'axios'
 import Users from '../components/Users'
 
 import fetch from '../utils/fetch'
+import jwt from '../utils/jwt'
 
 const UsersList = () => {
   const [users, setUsers] = useState()
@@ -16,6 +17,9 @@ const UsersList = () => {
       try {
         const response = await fetch.get('/users', {
           cancelToken: source.token,
+          headers: {
+            Authorization: `Bearer ${jwt.getToken()}`,
+          },
         })
         const users = response.data.users
         setUsers(users)

--- a/src/components/UsersSearchPanel.js
+++ b/src/components/UsersSearchPanel.js
@@ -5,6 +5,7 @@ import UsersSearchForm from './UsersSearchForm'
 import Users from './Users'
 
 import fetch from '../utils/fetch'
+import jwt from '../utils/jwt'
 
 const UsersPanelStyled = styled.div`
   width: 500px;
@@ -16,7 +17,11 @@ const UsersSearchPanel = ({ search }) => {
   const updateKeyword = (keyword) => {
     const loadData = async (keyword) => {
       try {
-        const response = await fetch.get(`/users/search?name=${keyword}`)
+        const response = await fetch.get(`/users/search?name=${keyword}`, {
+          headers: {
+            Authorization: `Bearer ${jwt.getToken()}`,
+          },
+        })
         const users = response.data.users
         setUsers(users)
       } catch (error) {

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -13,7 +13,7 @@ const LoginPage = () => {
   return (
     <Page title='Login'>
       {!isAuthenticated && <LoginForm setIsLoggedIn={setIsLoggedIn} />}
-      {isAuthenticated && isLoggedIn && <Redirect to='/dashboard' />}
+      {isAuthenticated && isLoggedIn && <Redirect to='/' />}
     </Page>
   )
 }

--- a/src/pages/RegisterPage.js
+++ b/src/pages/RegisterPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Redirect } from 'react-router-dom'
 
 import Page from '../components/Page'
@@ -8,10 +8,12 @@ import { checkIsAuthenticated } from '../utils/auth'
 
 const RegisterPage = () => {
   const isAuthenticated = checkIsAuthenticated()
+  const [isRegistered, setIsRegistered] = useState()
 
   return (
     <Page title='Get Started'>
-      {!isAuthenticated ? <RegisterForm /> : <Redirect to='/' />}
+      {!isAuthenticated && <RegisterForm setIsRegistered={setIsRegistered} />}
+      {isRegistered && <Redirect to='/register/success' />}
     </Page>
   )
 }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -8,11 +8,15 @@ export const checkIsAuthenticated = () => {
   // Asynchronous user validation
   const validate = async () => {
     try {
-      const validatedUser = await fetch('/users/validate')
+      const validatedUser = await fetch.get('/users/validate', {
+        headers: {
+          Authorization: `Bearer ${jwt.getToken()}`,
+        },
+      })
       if (validatedUser) return true
       else return false
     } catch (error) {
-      console.log('Error when checkIsAuthenticated', error.message)
+      console.log(error)
     }
   }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,17 +1,8 @@
 import axios from 'axios'
 
-import storage from './storage'
-
 const fetch = axios.create({
   baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8000',
   timeout: 2000,
-  headers: {
-    // Will be replaced by actual JWT or token header if authenticated
-    Authorization: storage.getKey('token')
-      ? `Bearer ${storage.getKey('token')}`
-      : '',
-    'X-App-Header': 'project-auth-react',
-  },
 })
 
 export default fetch


### PR DESCRIPTION
Remove headers config when `axios.create()`. Because it causes unexpected invalid `headers: Authorization`. Especially when doing registration and login.

Just put `headers` every time we do `get` and `post` request that requires a token.